### PR TITLE
Poulet4 interpreter fixes

### DIFF
--- a/core/EvalExpr.v
+++ b/core/EvalExpr.v
@@ -1438,7 +1438,7 @@ Proof.
   - destruct_match H0.
     + destruct l. 1: inversion H0. inversion H2; subst.
       * simpl in H13. unfold eval_read_var in H0. destruct st. simpl in *.
-        eapply mem_denote_get in H1; eauto. red in H1. rewrite H13 in H1. auto.
+        eapply mem_denote_get in H1; eauto. red in H1. Result.simpl_result_all. rewrite H13 in H1. auto.
       * rewrite H3 in H12; inversion H12.
     + inversion H2; subst. 1: rewrite H3 in H12; inversion H12.
       unfold loc_to_sval_const in H13. rewrite H0 in H13. inversion H13.
@@ -1794,6 +1794,7 @@ Proof.
   induction lv; unfold hoare_read; intros.
   - destruct loc; only 1 : inv H0.
     inv H2.
+    simpl; Result.simpl_result_all.
     eapply eval_read_var_sound; eauto.
   - simpl in H0.
     destruct (eval_read a_mem lv) eqn:?. 2 : inv H0.

--- a/core/Tactics.v
+++ b/core/Tactics.v
@@ -955,11 +955,15 @@ Ltac P4assert Q :=
 (* We need to specify the type of ge to prevent target from being unfolded in the type of ge. *)
 Ltac get_am_ge prog :=
   let ge := eval compute -[PathMap.empty PathMap.set] in (gen_am_ge prog) in
-  exact (ge : (@genv _ ltac:(typeclasses eauto))).
+    match ge with
+    | Result.Ok ?gev => exact (gev : (@genv _ ltac:(typeclasses eauto)))
+    end.
 
 Ltac get_ge am_ge prog :=
   let ge := eval compute -[am_ge PathMap.empty PathMap.set] in (gen_ge' am_ge prog) in
-  exact (ge : (@genv _ ltac:(typeclasses eauto))).
+    match ge with
+    | Result.Ok ?gev => exact (gev : (@genv _ ltac:(typeclasses eauto)))
+    end.
 
 Definition dummy_fundef {tags_t} : @fundef tags_t := FExternal "" "".
 Opaque dummy_fundef.

--- a/core/Tactics.v
+++ b/core/Tactics.v
@@ -952,18 +952,19 @@ Ltac P4assert Q :=
 
 (* Term-generating tactics *)
 
+Ltac force_res thunkv :=
+  match thunkv with
+  | Result.Ok ?v => exact v
+  end.
+
 (* We need to specify the type of ge to prevent target from being unfolded in the type of ge. *)
 Ltac get_am_ge prog :=
   let ge := eval compute -[PathMap.empty PathMap.set] in (gen_am_ge prog) in
-    match ge with
-    | Result.Ok ?gev => exact (gev : (@genv _ ltac:(typeclasses eauto)))
-    end.
+    force_res ge.
 
 Ltac get_ge am_ge prog :=
   let ge := eval compute -[am_ge PathMap.empty PathMap.set] in (gen_ge' am_ge prog) in
-    match ge with
-    | Result.Ok ?gev => exact (gev : (@genv _ ltac:(typeclasses eauto)))
-    end.
+    force_res ge.
 
 Definition dummy_fundef {tags_t} : @fundef tags_t := FExternal "" "".
 Opaque dummy_fundef.

--- a/core/Tofino.v
+++ b/core/Tofino.v
@@ -10,15 +10,21 @@ Require Export ProD3.core.TofinoSpec.
 
 Ltac get_am_ge prog ::=
   let ge := eval compute -[PathMap.empty PathMap.set extern_match] in (gen_am_ge prog) in
-  exact (ge : (@genv _ target)).
+    match ge with
+    | Result.Ok ?gev => exact (gev : (@genv _ target))
+    end.
 
 Ltac get_ge am_ge prog ::=
   let ge := eval compute -[am_ge PathMap.empty PathMap.set extern_match] in (gen_ge' am_ge prog) in
-  exact (ge : (@genv _ target)).
+    match ge with
+    | Result.Ok ?gev => exact (gev : (@genv _ target))
+    end.
 
 Ltac get_init_es am_ge prog :=
   let init_es := eval compute -[am_ge PathMap.empty PathMap.set extern_match] in (gen_init_es' am_ge prog) in
-  exact (init_es : (@Target.extern_state _ _ (@extern_sem _ _ target))).
+    match init_es with
+    | Result.Ok ?init_esv => exact (init_esv : (@Target.extern_state _ _ (@extern_sem _ _ target)))
+    end.
 
 Ltac get_am_fd ge am_ge p :=
   let am_sem := eval compute -[am_ge extern_match] in

--- a/core/V1ModelSpec.v
+++ b/core/V1ModelSpec.v
@@ -4,7 +4,7 @@ Require Import Poulet4.P4light.Syntax.Typed.
 Require Import Poulet4.P4light.Syntax.Syntax.
 Require Import Poulet4.P4light.Syntax.Value.
 Require Import Poulet4.P4light.Semantics.Semantics.
-Require Import Poulet4.P4light.Architecture.V1Model.
+Require Import Poulet4.P4light.Architecture.V1ModelTarget.
 Require Import Poulet4.P4light.Syntax.P4Notations.
 Require Import Poulet4.Utils.P4Arith.
 Require Import ProD3.core.Coqlib.

--- a/examples/bloomfilter/switch.v
+++ b/examples/bloomfilter/switch.v
@@ -4,7 +4,7 @@ Require Import Poulet4.P4light.Syntax.Value.
 Require Import Poulet4.P4light.Semantics.Semantics.
 Require Import Poulet4.P4light.Syntax.P4defs.
 Require Import Poulet4.P4light.Syntax.P4Notations.
-Require Import Poulet4.P4light.Architecture.V1Model.
+Require Import Poulet4.P4light.Architecture.V1ModelTarget.
 Require Import ProD3.core.SvalRefine.
 Require Import ProD3.core.Members.
 Require Import Coq.Strings.String.

--- a/examples/bloomfilter/verif.v
+++ b/examples/bloomfilter/verif.v
@@ -7,11 +7,12 @@ Import ListNotations.
 Require Import Poulet4.Utils.Maps.
 Require Import Poulet4.P4light.Semantics.Semantics.
 Require Import Poulet4.P4light.Transformations.SimplExpr.
-Require Import Poulet4.P4light.Architecture.V1Model.
+Require Import Poulet4.P4light.Architecture.V1ModelTarget.
 Require Import Poulet4.Utils.P4Arith.
 
 Require Import ProD3.core.Core.
 Require Import ProD3.core.V1ModelSpec.
+Require Import ProD3.core.Tactics.
 Require Import ProD3.examples.bloomfilter.p4ast.
 Require Import ProD3.examples.sbf.ConFilter.
 Require Import ProD3.examples.sbf.general_bf.
@@ -26,11 +27,13 @@ Notation Sval := (@ValueBase (option bool)).
 Opaque PathMap.empty PathMap.set.
 
 (* Global environment *)
-Definition ge : genv := Eval compute in gen_ge prog.
+Definition am_ge := ltac:(get_am_ge prog).
+Definition ge := ltac:(get_ge am_ge prog).
 
 (* Initial extern state *)
-Definition instantiation := Eval compute in instantiate_prog ge (ge_typ ge) prog.
-Definition init_es := Eval compute in snd instantiation.
+Definition instantiation := ltac:(let t := eval compute in (instantiate_prog ge (ge_typ ge) prog) in
+                                    force_res t).
+Definition init_es := force_res (eval compute in snd instantiation).
 
 Transparent IdentMap.empty IdentMap.set PathMap.empty PathMap.set.
 

--- a/examples/bloomfilter/verif.v
+++ b/examples/bloomfilter/verif.v
@@ -33,7 +33,7 @@ Definition ge := ltac:(get_ge am_ge prog).
 (* Initial extern state *)
 Definition instantiation := ltac:(let t := eval compute in (instantiate_prog ge (ge_typ ge) prog) in
                                     force_res t).
-Definition init_es := force_res (eval compute in snd instantiation).
+Definition init_es := snd instantiation.
 
 Transparent IdentMap.empty IdentMap.set PathMap.empty PathMap.set.
 


### PR DESCRIPTION
Hi, I have some changes in the branch `poulet4-interpreter` over in the Petr4 repo that I would like to merge into `poulet4`. I took a look to see how much my changes break Verifiable P4 and in this PR I fix the issues, so far as I can tell.

Can someone take a look at what I've changed and let me know if it builds on your machine (after installing poulet4 from the poulet4-interpreter branch)? I am seeing some build problems that don't appear to be due to the poulet4-interpreter changes, e.g.,
```
File "./examples/sbf/FlowProperty.v", line 42, characters 63-65:
Error:
In environment
f : list packet
i : Z
The term "Tc" has type "Z -> Z -> Z" while it is expected to have type "Z".
```

And this, which I assume means I'm missing some VST-related opam package?
```
File "./examples/sbf/flow_proof.v", line 1, characters 0-35:
Error: Cannot find a physical path bound to logical path VST.floyd.proofauto.
```